### PR TITLE
DroneCI integration

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,0 +1,5 @@
+image: bradrydzewski/python:2.7
+script:
+    - pip install tox
+    - tox
+

--- a/.drone.yml
+++ b/.drone.yml
@@ -1,4 +1,4 @@
-image: bradrydzewski/python:2.7
+image: python:2.7
 script:
     - pip install tox
     - tox


### PR DESCRIPTION
This adds DroneCI configuration to the repository. 

This is runnable either in drone.io or by registration in our CI service - you've got the details. All tests are run in the official python 2.7 docker container.

For more information on what you can do with the drone.yaml see the [project readme](https://github.com/drone/drone/blob/v0.2.1/README.md#builds)
